### PR TITLE
Fix broken provider references when searching from a constructor annotated with @Inject.

### DIFF
--- a/src/com/squareup/ideaplugin/dagger/PsiConsultantImpl.java
+++ b/src/com/squareup/ideaplugin/dagger/PsiConsultantImpl.java
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiModifierListOwner;
@@ -107,6 +108,10 @@ public class PsiConsultantImpl {
   }
 
   public static PsiClass getReturnClassFromMethod(PsiMethod psiMethod) {
+    if (psiMethod.isConstructor()) {
+      return psiMethod.getContainingClass();
+    }
+
     PsiClassType returnType = ((PsiClassType) psiMethod.getReturnType());
     if (returnType != null) {
       return returnType.resolve();


### PR DESCRIPTION
Fix broken provides references when attempting to search for injection sources on a constructor annotated with @Inject.

Details:
- PsiConsultantImpl.getReturnClassFromMethod returns null when the method is a constructor. This patch fixes this function to return the containing class associated with the constructor.